### PR TITLE
WIP - Add purchase_url to free bikes and stations

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -204,6 +204,7 @@ stations              | Yes       | Array that contains one object per station i
 - is_renting          | Yes       | 1/0 boolean - is the station currently renting bikes (even if the station is empty, if it is set to allow rentals this value should be 1)
 - is_returning        | Yes       | 1/0 boolean - is the station accepting bike returns (if a station is full but would allow a return if it was not full then this value should be 1)
 - last_reported       | Yes       | Timestamp of the last time this station reported its status to the backend
+- purchase_url        | Optional  | A fully qualified URL, to which the station_id can be passed as a parameter, where a user can rent a bike at this station_id.  For example, if a fully qualified URL to a rental webpage for this station is http://app.socialbicycles.com/map?station_id=1219, then the value of purchase_url would be http://app.socialbicycles.com/map, and station_id would be 1219.
 
 ### free_bike_status.json
 Describes bikes that are not at a station and are not currently in the middle of an active ride.
@@ -216,6 +217,7 @@ bikes             | Yes       | Array that contains one object per bike that is 
 - lon             | Yes       | Longitude of the bike. The field value must be a valid WGS 84 latitude. See: http://en.wikipedia.org/wiki/World_Geodetic_System
 - is_reserved     | Yes       | 1/0 value - is the bike currently reserved for someone else
 - is_disabled     | Yes       | 1/0 value - is the bike currently disabled (broken)
+- purchase_url    | Optional  | A fully qualified URL, to which the bike_id can be passed as a parameter, where a user can rent this bike_id.  For example, if a fully qualified URL to a rental webpage for this bike is http://app.socialbicycles.com/map?bike_id=3503, then the value of purchase_url would be http://app.socialbicycles.com/map, and bike_id would be 3503.
 
 ### system_hours.json
 Describes the system hours of operation. A JSON array of hours defined as follows:


### PR DESCRIPTION
Applications consuming GBFS would like to show markers for the available bikes and stations on the map, and when the user taps on these show a link that they can follow to rent that particular bike (for free bikes) or a bike at that particular station (for station-based systems).

Currently, to implement this feature rental URLs need to be hard-coded in the application for each bike/share vendor/deployment.

This patch proposes the capability to discover these rental_urls directly from the GBFS feed for each free bike and station.  It's intended to be a starting point for discussion, so comments/improvements are welcome.

We've implemented the rental link via the proprietary hard-coded approach mentioned above at http://maps.usf.edu/#layers (enable the "Share-A-Bull" Bikes layer) for the SoBi deployment at USF:

![image](https://cloud.githubusercontent.com/assets/928045/14868221/8750feb8-0c9a-11e6-8801-8baaebc2022d.png)

If SoBi is willing to prototype this field in their GBFS feed for the USF deployment we'd be willing to try it out in the above webapp.  

cc @fruminator @jmfield2
